### PR TITLE
build: use typescript to help out with common errors

### DIFF
--- a/backend/tealfleet/package.json
+++ b/backend/tealfleet/package.json
@@ -4,7 +4,8 @@
   "description": "TealFleet backend server",
   "main": "app.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "start": "nodemon --watch \"src/**\" --ext \"ts,js,json\" --exec \"ts-node src/app.js\""
   },
   "author": "Jakob Jozelj",
   "dependencies": {
@@ -12,7 +13,11 @@
     "dotenv": "^16.3.1",
     "express": "^4.18.2",
     "express-session": "^1.17.3",
-    "nodemon": "^3.0.1",
     "pg": "^8.11.3"
+  },
+  "devDependencies": {
+    "@tsconfig/node20": "^20.1.2",
+    "nodemon": "^3.0.1",
+    "ts-node": "^10.9.1"
   }
 }

--- a/backend/tealfleet/tsconfig.json
+++ b/backend/tealfleet/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "@tsconfig/node12/tsconfig.json",
+  "compilerOptions": {
+    "allowJs": true,
+    "checkJs": true,
+    "noImplicitAny": false,
+    "outDir": "dist/"
+  },
+  "include": ["src/**/*"]
+}


### PR DESCRIPTION
You can now use `npm start` to run the backend project with typescript (ts-node) and watching for code changes (nodemon).

It will complain about types a bit, but only as a warning in IDE. It should help you out with any typos, wrong export/imports.

You are not required to start writing `.ts` files with types. You can install packages like `@types/express` and `@types/pg` if you want better code completion by IDE, but it's optional.

Example of error found by TypesScript (VsCode) with this changes:
![slika](https://github.com/iakobj/TealFleetCode/assets/1910649/c3bd8602-c17d-4f94-ae3b-29d03e4b634e)

Which is much easier to understand than the node errors that happen when executing the `app.js`.
